### PR TITLE
Update dependency list to include puppet-upstart

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,6 +7,7 @@ Dependencies
 ------------
 
 - [stdlib](https://github.com/puppetlabs/puppetlabs-stdlib)
+- [puppet-upstart](https://github.com/bison/puppet-upstart)
 
 Copyright and License
 ---------------------


### PR DESCRIPTION
There is an implied dependency on your puppet-upstart module - this change makes that more explicit / obvious.
